### PR TITLE
fix: 修复页码显示不正确的bug

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -91,7 +91,11 @@
     <span class="numFirst">
         <a class="pageFirst" href="{{ $paginator.First.URL | absURL }}">{{ "1" }}</a>
       </span>
+    {{- end }}
+    {{- if gt (sub $paginator.PageNumber 1) 2 }}
     &nbsp;...&nbsp;
+    {{- end }}
+    {{- if gt (sub $paginator.PageNumber 1) 1 }}
     <span class="numPrev">
         <a class="pagePrev" href="{{ $paginator.Prev.URL | absURL }}">{{ sub $paginator.PageNumber 1 }}</a>
       </span>
@@ -101,11 +105,15 @@
       <a class="pageNow" href="{{ $paginator.URL | absURL }}">{{ $paginator.PageNumber }}</a>
     </span>
 
-    {{- if not (eq $paginator.PageNumber $paginator.TotalPages) }}
+    {{- if lt (add $paginator.PageNumber 1) $paginator.TotalPages }}
     <span class="numNext">
         <a class="pageNext" href="{{ $paginator.Next.URL | absURL }}">{{ add $paginator.PageNumber 1 }}</a>
       </span>
+    {{- end }}
+    {{- if lt (add $paginator.PageNumber 2) $paginator.TotalPages }}
     &nbsp;...&nbsp;
+    {{- end }}
+    {{- if not (eq $paginator.PageNumber $paginator.TotalPages) }}
     <span class="numLast">
         <a class="pageLast" href="{{ $paginator.Last.URL | absURL }}">{{ $paginator.TotalPages }}</a>
       </span>


### PR DESCRIPTION
目前的页码显示不正确，比如有三页，如果当前页面在第二页，显示的效果为：1 ... 1 2 3 ... 3