### PR TITLE
fix: 修复弃用的参数 paginate, twitter 和 .Site.Social

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,7 @@ buildExpired: false
 googleAnalytics:  # 谷歌统计
 # Copyright: Sulv
 
-paginate: 15    # 首页每页显示的文章数
+pagination.pagerSize: 15    # 首页每页显示的文章数
 summaryLength: 140 # 文章概览的自字数，默认70
 
 minify:
@@ -213,7 +213,7 @@ privacy:
     disabled: false
     simple: true
 
-  twitter:
+  x:
     disabled: false
     enableDNT: true
     simple: true
@@ -229,6 +229,6 @@ privacy:
 services:
   instagram:
     disableInlineCSS: true
-  twitter:
+  x:
     disableInlineCSS: true
         

--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -49,4 +49,4 @@
 {{ end }}{{ end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}
+{{- with .Site.Params.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -28,6 +28,6 @@
 {{- end }}
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
-{{ with site.Social.twitter -}}
+{{ with .Site.Params.Social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}"/>
 {{ end -}}


### PR DESCRIPTION
hugo server -D 运行的时候有几个报错：

1. site config key paginate was deprecated ...Use pagination.pagerSize instead. 根据提示在 config 文件里把 paginate 改为 pagination.pagerSize

2. site config key privacy.twitter.disable was deprecated ... Use privacy.x.disable instead. 还是 config 文件，有几处地方把 twitter 改为 x

3.  另外有 .Site.Social 报错：
`ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and subsequently removed. Implement taxonomy 'social' or use .Site.Params.Social instead.`
根据 https://github.com/adityatelange/hugo-PaperMod/issues/1573 提到的方法修改